### PR TITLE
Guard against empty error response

### DIFF
--- a/lib/rjmetrics-client/client.rb
+++ b/lib/rjmetrics-client/client.rb
@@ -108,6 +108,11 @@ module RJMetrics
       rescue RestClient::Exception => error
         begin
           response = JSON.parse(error.response)
+
+          unless response
+            raise InvalidRequestException, "The Import API returned: #{error.http_code} #{error.message}"
+          end
+
           raise InvalidRequestException,
             "The Import API returned: #{response['code']} #{response['message']}. Reasons: #{response['reasons']}"
         rescue JSON::ParserError, TypeError => json_parse_error


### PR DESCRIPTION
We're getting a couple of `NoMethodError: undefined method '[]' for nil:NilClass` exceptions at https://github.com/RJMetrics/RJMetrics-ruby/blob/master/lib/rjmetrics-client/client.rb#L112 from time to time, those are usually fix themselves on subsequent push attempts but still it would be nice to raise a proper exception on error.

This is happening when `error.response` is `nil`  so `JSON.parse` returns nil as well.