### PR TITLE
Use authorize endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,3 +40,6 @@ DEPENDENCIES
   rjmetrics-client!
   rspec (> 0)
   yard (> 0)
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rjmetrics-client (0.5.2)
+    rjmetrics-client (0.6.0)
       json (>= 1.7.7)
       rest-client (>= 1.6.7)
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ end
 
 desc "Run RSpec unit tests"
 task :test do
-  system("rspec test/client_spec.rb --format nested")
+  system("rspec test/client_spec.rb --format documentation")
 end
 
 desc "Generate docs"

--- a/lib/rjmetrics-client/client.rb
+++ b/lib/rjmetrics-client/client.rb
@@ -30,11 +30,10 @@ module RJMetrics
       @timeout_in_seconds = timeout_in_seconds
     end
 
-    # Checks if the provided Client ID and API Key are valid credentials by requesting from the RJMetrics API Sandbox.
+    # Checks if the provided Client ID and API Key are valid.
     def authenticated?
-      test_data = {:keys => [:id], :id => 1}
       begin
-        pushData("test", test_data, SANDBOX_BASE)
+        makeAuthAPICall()
       rescue InvalidRequestException
         return false
       end
@@ -88,6 +87,28 @@ module RJMetrics
 
       if not url.is_a? String
         raise ArgumentError, "Invalid url: '#{url}' -- must be a string."
+      end
+    end
+
+    def makeAuthAPICall(url = API_BASE)
+      request_url = "#{url}/client/#{@client_id}/authorize?apikey=#{@api_key}"
+      begin
+        response = RestClient.get(request_url)
+        return response
+      rescue RestClient::Exception => error
+        begin
+          response = JSON.parse(error.response)
+
+          unless response
+            raise InvalidRequestException, "The Import API returned: #{error.http_code} #{error.message}"
+          end
+
+          raise InvalidRequestException,
+            "The Import API returned: #{response['code']} #{response['message']}. Reasons: #{response['reasons']}"
+        rescue JSON::ParserError, TypeError => json_parse_error
+          raise InvalidResponseException,
+            "RestClientError: #{error.class}\n Message: #{error.message}\n Response Code: #{error.http_code}\n Full Response: #{error.response}"
+        end
       end
     end
 

--- a/lib/rjmetrics-client/client.rb
+++ b/lib/rjmetrics-client/client.rb
@@ -90,8 +90,9 @@ module RJMetrics
       end
     end
 
+    # Authenticates with the RJMetrics Data Import API
     def makeAuthAPICall(url = API_BASE)
-      request_url = "#{url}/client/#{@client_id}/authorize?apikey=#{@api_key}"
+      request_url = "#{url}/client/#{@client_id}/authenticate?apikey=#{@api_key}"
       begin
         response = RestClient.get(request_url)
         return response

--- a/rjmetrics_client.gemspec
+++ b/rjmetrics_client.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'rjmetrics-client'
-  s.version     = '0.5.2'
-  s.date        = '2014-04-07'
+  s.version     = '0.6.0'
+  s.date        = '2016-03-03'
   s.summary     = "RJMetrics Data Import API Client Library"
   s.description = "RJMetrics Data Import API Client Library"
   s.authors     = ["Owen Jones"]

--- a/test/client_spec.rb
+++ b/test/client_spec.rb
@@ -69,12 +69,9 @@ describe RJMetrics::Client do
       it "will return true" do
         client = RJMetrics::Client.new(valid_client_id, valid_api_key, valid_timeout)
 
-        authenticate_table_name = "test"
-        authenticate_data = Array.new(1, import_data_klass.new(1))
-
         expect(RestClient).to receive(:get)
         .with(
-          "#{sandbox_base}/client/#{valid_client_id}/authenticate?apikey=#{valid_api_key}",
+          "#{api_base}/client/#{valid_client_id}/authenticate?apikey=#{valid_api_key}",
         )
         .and_return("{\"code:\" 200}")
 

--- a/test/client_spec.rb
+++ b/test/client_spec.rb
@@ -72,17 +72,11 @@ describe RJMetrics::Client do
         authenticate_table_name = "test"
         authenticate_data = Array.new(1, import_data_klass.new(1))
 
-        expect(RestClient).to receive(:post)
+        expect(RestClient).to receive(:get)
         .with(
-          "#{sandbox_base}/client/#{valid_client_id}/table/#{authenticate_table_name}/data?apikey=#{valid_api_key}",
-          authenticate_data.to_json,
-          {
-            :content_type => :json,
-            :accept => :json,
-            :timeout => valid_timeout
-          }
+          "#{sandbox_base}/client/#{valid_client_id}/authenticate?apikey=#{valid_api_key}",
         )
-        .and_return("{\"code:\" 200, \"message\": \"created\"}")
+        .and_return("{\"code:\" 200}")
 
         client.authenticated?.should eq(true)
       end


### PR DESCRIPTION
### Motivation
We added the authenticate endpoint to the IAPI, let's use it.   That way the sandbox machine will no longer be production critical.

### API changes
None

### Implementation Notes
The endpoint is called authenticate.  Meaning the apikey provided exists, and matches the client-id in the url.  Implicitly, a 200 response means the apikey has at least REGULAR permissions, meaning the key can push data.  That's an authorization concern, but still a good question to answer.  

### Functional Tests
Ran the example code.
```
➜  RJMetrics-ruby git:(feature/use-authorize) ✗ ruby examples/orders_table.rb                             
Synced order with id 1
Synced order with id 2
Synced order with id 3
Synced order with id 4
Synced order with id 5
```